### PR TITLE
Upgrade to latest commit in nixos-unstable channel

### DIFF
--- a/nixpkgs-pinned.nix
+++ b/nixpkgs-pinned.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/0a7e258012b60cbe530a756f09a4f2516786d370.tar.gz";
-  sha256 = "1qcnxkqkw7bffyc17mqifcwjfqwbvn0vs0xgxnjvh9w0ssl2s036";
+  url = "https://github.com/NixOS/nixpkgs/archive/32bcd72bf28a971c9063a9cdcc32effe49f49331.tar.gz";
+  sha256 = "1f74m18r6xl9s55jbkj9bjhdxg2489kwjam4d96pf9rzq0i1f8li";
 }


### PR DESCRIPTION
NixOS 18.09 was forked from unstable recently.